### PR TITLE
Suppressing alert with DISABLE_ALERT environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,6 @@ alert('hey!', 'yad')
 
 `alert` also has a cli. `npm i -g alert` and run `alert 'sup brah'`.
 
+To disable alert for testing purposes or otherwise, you can set an environment variable `DISABLE_ALERT=1`.
+
 [LICENSE](./LICENSE.md)

--- a/node.js
+++ b/node.js
@@ -59,6 +59,7 @@ const nameMap = {
 
 const getAlert = (input = '', thingToUse = '') => {
   const execInput = (cmd) => execCmd(cmd(input))
+
   const pickFromNameMap = (option = bestUnixProgram) => {
     if (option !== 'console') {
       if (nameMap[option]) {

--- a/node.js
+++ b/node.js
@@ -59,7 +59,6 @@ const nameMap = {
 
 const getAlert = (input = '', thingToUse = '') => {
   const execInput = (cmd) => execCmd(cmd(input))
-
   const pickFromNameMap = (option = bestUnixProgram) => {
     if (option !== 'console') {
       if (nameMap[option]) {
@@ -87,4 +86,4 @@ const getAlert = (input = '', thingToUse = '') => {
   }
 }
 
-module.exports = getAlert
+module.exports = process.env.DISABLE_ALERT !== '1' ? getAlert : () => {}


### PR DESCRIPTION
# Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [x] minor
* [ ] patch

# Further Information (screenshots, bug report links, etc.)

Minor non-breaking change to allow suppression of `alert` by setting environment variable `DISABLE_ALERT=1`. If the variable is set, a noop will be returned instead of the `getAlert` function.

Added a line to README to account for the change.

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current and LTS Node)
